### PR TITLE
Allow login for local and anonymous user

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -35,6 +35,7 @@ var config_data = {
             'history': 'ZAutomation/api/v1/history',
             'login': 'ZAutomation/api/v1/login',
             'logout': 'ZAutomation/api/v1/logout',
+            'session': 'ZAutomation/api/v1/session',
             'backup': 'ZAutomation/api/v1/backup',
             'restore': 'ZAutomation/api/v1/restore',
             'tokens': 'ZAutomation/api/v1/modules/tokens',

--- a/app/controllers/auth.js
+++ b/app/controllers/auth.js
@@ -20,7 +20,7 @@ myAppController.controller('LoginController', function($scope, $location, $windo
     };
     if(dataService.getUser()){
         $scope.input.form = false;
-         window.location = '#/elements/dashboard/1?login';
+        window.location = '#/elements/dashboard/1?login';
     }
     $scope.loginLang = ($scope.lastLogin != undefined && angular.isDefined($cookies.lang)) ? $cookies.lang : false;
     /**
@@ -40,6 +40,7 @@ myAppController.controller('LoginController', function($scope, $location, $windo
         dataFactory.sessionApi().then(function(response) {
             $scope.processUser(response.data.data);
             if (!hasCookie) {
+                $location.path('/elements/dashboard/1');
                 $window.location.reload();
             }
         });
@@ -57,7 +58,6 @@ myAppController.controller('LoginController', function($scope, $location, $windo
         //$scope.loading = false;
         $scope.input.form = false;
         //$window.location.href = '#/elements/dashboard/1?login';
-        $location.path('/elements/dashboard/1');
     };
     /**
      * Login proccess
@@ -67,6 +67,7 @@ myAppController.controller('LoginController', function($scope, $location, $windo
         $scope.loading = {status: 'loading-spin', icon: 'fa-spinner fa-spin', message: $scope._t('loading')};
         $scope.alert = {message: false};
         dataFactory.logInApi(input).then(function(response) {
+            var redirectTo = '#/elements/dashboard/1?login';
             $scope.processUser(response.data.data);
             if (input.fromexpert) {
                 window.location.href = $scope.cfg.expert_url;
@@ -75,6 +76,7 @@ myAppController.controller('LoginController', function($scope, $location, $windo
             if (input.password === $scope.cfg.default_credentials.password) {
                 redirectTo = '#/password';
             }
+            window.location = redirectTo;
             $window.location.reload();
         }, function(error) {
             var message = $scope._t('error_load_data');

--- a/app/controllers/auth.js
+++ b/app/controllers/auth.js
@@ -31,6 +31,34 @@ myAppController.controller('LoginController', function($scope, $location, $windo
         $cookies.lang = lang;
         $scope.loadLang(lang);
     };
+    
+    /**
+     * Get session (ie for users holding only a session id, or users that require no login)
+     */
+    $scope.getSession = function() {
+        var hasCookie = ($cookies.user) ? true:false;
+        dataFactory.sessionApi().then(function(response) {
+            $scope.processUser(response.data.data);
+            if (!hasCookie) {
+                $window.location.reload();
+            }
+        });
+    };
+    /**
+     * Login with selected data from server response
+     */
+    $scope.processUser = function(user) { 
+        if($scope.loginLang){
+            user.lang = $scope.loginLang;
+        }
+        dataService.setZWAYSession(user.sid);
+        dataService.setUser(user);
+        dataService.setLastLogin(Math.round(+new Date() / 1000));
+        //$scope.loading = false;
+        $scope.input.form = false;
+        //$window.location.href = '#/elements/dashboard/1?login';
+        $location.path('/elements/dashboard/1');
+    };
     /**
      * Login proccess
      */
@@ -39,19 +67,7 @@ myAppController.controller('LoginController', function($scope, $location, $windo
         $scope.loading = {status: 'loading-spin', icon: 'fa-spinner fa-spin', message: $scope._t('loading')};
         $scope.alert = {message: false};
         dataFactory.logInApi(input).then(function(response) {
-            var redirectTo = '#/elements/dashboard/1?login';
-            var user = response.data.data;
-            if ($scope.loginLang) {
-                user.lang = $scope.loginLang;
-            }
-            dataService.setZWAYSession(user.sid);
-            dataService.setUser(user);
-            dataService.setLastLogin(Math.round(+new Date() / 1000));
-            //$scope.loading = false;
-            $scope.input.form = false;
-            //$window.location.href = '#/elements/dashboard/1?login';
-            //console.log(user);
-            //$location.path('/elements/dashboard/1?login');
+            $scope.processUser(response.data.data);
             if (input.fromexpert) {
                 window.location.href = $scope.cfg.expert_url;
                 return;
@@ -59,9 +75,6 @@ myAppController.controller('LoginController', function($scope, $location, $windo
             if (input.password === $scope.cfg.default_credentials.password) {
                 redirectTo = '#/password';
             }
-
-            window.location = redirectTo;
-
             $window.location.reload();
         }, function(error) {
             var message = $scope._t('error_load_data');
@@ -73,12 +86,13 @@ myAppController.controller('LoginController', function($scope, $location, $windo
         });
     };
     /**
-     * Login from url
+     * Login from url or session
      */
     if ($routeParams.login && $routeParams.password) {
         $scope.login($routeParams);
+    } else {
+        $scope.getSession();
     }
-
 });
 /**
  * Password controller
@@ -230,7 +244,7 @@ myAppController.controller('PasswordResetController', function($scope, $routePar
 myAppController.controller('LogoutController', function($scope, dataService, dataFactory) {
     $scope.logout = function() {
         dataService.logOut();
-         dataFactory.getApi('logout').then(function(response) {});
+        dataFactory.getApi('logout').then(function(response) {});
     };
     $scope.logout();
 

--- a/app/controllers/auth.js
+++ b/app/controllers/auth.js
@@ -92,7 +92,7 @@ myAppController.controller('LoginController', function($scope, $location, $windo
      */
     if ($routeParams.login && $routeParams.password) {
         $scope.login($routeParams);
-    } else {
+    } else if (!$routeParams.logout) {
         $scope.getSession();
     }
 });
@@ -245,8 +245,9 @@ myAppController.controller('PasswordResetController', function($scope, $routePar
  */
 myAppController.controller('LogoutController', function($scope, dataService, dataFactory) {
     $scope.logout = function() {
-        dataService.logOut();
-        dataFactory.getApi('logout').then(function(response) {});
+        dataFactory.getApi('logout').then(function(response) {
+            dataService.logOut();
+        });
     };
     $scope.logout();
 

--- a/app/services/factories.js
+++ b/app/services/factories.js
@@ -31,7 +31,6 @@ myAppFactory.factory('dataFactory', function($http, $filter, $q, myCache, dataSe
     }
     return({
         logInApi: logInApi,
-        logOutApi: logOutApi,
         sessionApi: sessionApi,
         getApiLocal: getApiLocal,
         getApi: getApi,
@@ -76,19 +75,6 @@ myAppFactory.factory('dataFactory', function($http, $filter, $q, myCache, dataSe
             method: "post",
             data: data,
             url: cfg.server_url + cfg.api['login']
-        }).then(function(response) {
-            return response;
-        }, function(response) {// something went wrong
-            //return response;
-            return $q.reject(response);
-        });
-    }
-    
-    // Get api data
-    function logOutApi() {
-        return $http({
-            method: "get",
-            url: cfg.server_url + cfg.api['logout']
         }).then(function(response) {
             return response;
         }, function(response) {// something went wrong

--- a/app/services/factories.js
+++ b/app/services/factories.js
@@ -31,6 +31,8 @@ myAppFactory.factory('dataFactory', function($http, $filter, $q, myCache, dataSe
     }
     return({
         logInApi: logInApi,
+        logOutApi: logOutApi,
+        sessionApi: sessionApi,
         getApiLocal: getApiLocal,
         getApi: getApi,
         deleteApi: deleteApi,
@@ -74,6 +76,32 @@ myAppFactory.factory('dataFactory', function($http, $filter, $q, myCache, dataSe
             method: "post",
             data: data,
             url: cfg.server_url + cfg.api['login']
+        }).then(function(response) {
+            return response;
+        }, function(response) {// something went wrong
+            //return response;
+            return $q.reject(response);
+        });
+    }
+    
+    // Get api data
+    function logOutApi() {
+        return $http({
+            method: "get",
+            url: cfg.server_url + cfg.api['logout']
+        }).then(function(response) {
+            return response;
+        }, function(response) {// something went wrong
+            //return response;
+            return $q.reject(response);
+        });
+    }
+    
+    // Get api data
+    function sessionApi() {
+        return $http({
+            method: "get",
+            url: cfg.server_url + cfg.api['session']
         }).then(function(response) {
             return response;
         }, function(response) {// something went wrong


### PR DESCRIPTION
When opening the login page a call to /ZAutomation/api/v1/session is made, requesting the session information in the same format as returned by a successful cal to /ZAutomation/api/v1/login. If a local user is available, the user gets redirected to the dashboard. See also https://github.com/Z-Wave-Me/home-automation/pull/301