### PR TITLE
Tag improvements

### DIFF
--- a/app/controllers/element.js
+++ b/app/controllers/element.js
@@ -639,9 +639,10 @@ myAppController.controller('ElementIdController', function ($scope, $q, $routePa
         instances: {}
     };
     $scope.tagList = [];
-    $scope.searchText = '';
+    $scope.search = {
+        text: ''
+    };
     $scope.suggestions = [];
-    $scope.autoCompletePanel = false;
 
     $scope.icons = [
         {
@@ -711,26 +712,24 @@ myAppController.controller('ElementIdController', function ($scope, $q, $routePa
     /**
      * Search me
      */
-    $scope.searchMe = function (search) {
+    $scope.searchMe = function () {
         $scope.suggestions = [];
-        $scope.autoCompletePanel = false;
-        if (search.length > 2) {
-            var foundText = findText($scope.tagList, search);
-            $scope.autoCompletePanel = (foundText) ? true : false;
-            console.log($scope.autoCompletePanel)
+        if ($scope.search.text.length >= 2) {
+            findText($scope.tagList, $scope.search.text,$scope.elementId.input.tags);
         }
     };
 
     /**
      * Add tag to list
      */
-    $scope.addTag = function (searchText) {
-        $scope.searchText = '';
-        $scope.autoCompletePanel = false;
-        if (!searchText || $scope.elementId.input.tags.indexOf(searchText) > -1) {
+    $scope.addTag = function (tag) {
+        tag = tag || $scope.search.text;
+        $scope.suggestions = [];
+        if (!tag || $scope.elementId.input.tags.indexOf(tag) > -1) {
             return;
         }
-        $scope.elementId.input.tags.push(searchText);
+        $scope.elementId.input.tags.push(tag);
+        $scope.search.text = '';
         return;
     };
     /**
@@ -738,7 +737,7 @@ myAppController.controller('ElementIdController', function ($scope, $q, $routePa
      */
     $scope.removeTag = function (index) {
         $scope.elementId.input.tags.splice(index, 1);
-        $scope.autoCompletePanel = false;
+        $scope.suggestions = [];
     };
     /**
      * Update an item
@@ -836,12 +835,13 @@ myAppController.controller('ElementIdController', function ($scope, $q, $routePa
     /**
      * Find text
      */
-    function findText(n, search) {
+    function findText(n, search, exclude) {
         var gotText = false;
         for (var i in n) {
             var re = new RegExp(search, "ig");
             var s = re.test(n[i]);
-            if (s) {
+            if (s
+                && (! _.isArray(exclude) || exclude.indexOf(n[i]) === -1)) {
                 $scope.suggestions.push(n[i]);
                 gotText = true;
             }

--- a/app/views/elements/element_id.html
+++ b/app/views/elements/element_id.html
@@ -100,15 +100,15 @@
                         <input name="add_tag" id="add_tag" type="text" 
                                          class="form-control"
                                          placeholder="{{_t('lb_add_tag')}}" 
-                                         ng-model="searchText" bb-key-event="searchMe(searchText);" data-toggle="dropdown" />
-                       <span class="input-group-addon clickable" title="{{_t('lb_add_tag')}}" ng-click="addTag(searchText)">
+                                         ng-model="search.text" bb-key-event="searchMe();" data-toggle="dropdown" />
+                       <span class="input-group-addon clickable" title="{{_t('lb_add_tag')}}" ng-click="addTag()">
                            <i class="fa fa-plus text-success"></i>
                        </span> 
-                       <div class="app-dropdown app-dropdown-left" ng-if="autoCompletePanel">
+                       <div class="app-dropdown app-dropdown-left" ng-if="suggestions.length">
                         <ul>
                            <li href="" ng-click="addTag(v)" 
-                               ng-repeat="v in suggestions | orderBy:'toString()'" 
-                               ng-if="elementId.input.tags.indexOf(v) === -1"><a href=""> <i class="fa fa-plus text-success"></i> {{v}}</a></li>
+                               ng-repeat="v in suggestions | orderBy:'toString()'">
+                               <a href=""> <i class="fa fa-plus text-success"></i> {{v}}</a></li>
                         </ul>
                         </div>
                     </div>

--- a/app/views/elements/elements_page.html
+++ b/app/views/elements/elements_page.html
@@ -54,13 +54,13 @@
                    ng-click="setFilter()" 
                    ng-class="_.isEmpty(dataHolder.devices.filter) == true ? 'active': ''">
                      {{_t('all_elements')}}
-                 </a>
+                </a>
                 <a class="btn btn-default btn-tag"
-                        ng-repeat="v in dataHolder.devices.tags" 
+                        ng-repeat="v in dataHolder.devices.tags|orderBy:'toString()'" 
                         ng-click="setFilter({tag: v})" 
                         ng-class="dataHolder.devices.filter.tag == v ? 'active': ''">
                      {{_t(v) | cutText:true:30}}
-                 </a>
+                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- fix field reset after tag add (was implemented but never worked, now taking search term form angular model and not as method argument)
- don't show empty autocomplete div if tags were found but are already used (no need for autoCompletePanel, but use the length of the result array to decide wether or not to show div)
- start autocomplete after two characters (usually users don't have many tags)
- sort tags alphabetically (easier to find tags

This is an improved and reworked version of https://github.com/Z-Wave-Me/zwave-smarthome/pull/110