### PR TITLE
Use probeType and not icon to select device controls

### DIFF
--- a/app/views/elements/widgets/switchMultilevel.html
+++ b/app/views/elements/widgets/switchMultilevel.html
@@ -1,7 +1,7 @@
 <!-- Switch multilevel -->
 <div class="widget-ctrl ctrl-left">
     <!-- mutilevel -->
-    <div class="btn-group" ng-if="v.metrics.icon == 'multilevel'">
+    <div class="btn-group" ng-if="v.probeType == 'multilevel'">
         <!-- Off -->
         <button class="btn btn-off" id="btn_off_{{ v.id}}"
             data-ng-click="runCmd(v.id + '/command/off', v.id)"
@@ -24,7 +24,7 @@
         </button>
     </div>
     <!-- blind -->
-    <div class="btn-group" ng-if="v.metrics.icon == 'blinds'">
+    <div class="btn-group" ng-if="v.probeType == 'motor'">
         <button 
             class="btn btn-off" id="btn_off_{{ v.id}}"
             data-ng-click="runCmd(v.id + '/command/off', v.id)"


### PR DESCRIPTION
This PR removes the reliance on metrics:icon to determine if a multilevel switch is a blind or a dimmer. 
https://github.com/Z-Wave-Me/home-automation/commit/63b8f219f8c8e361a8fa6ade6dd9b367ccd052ce added probeType = motor and probeType = multilevel to home-automation

This also adresses https://github.com/Z-Wave-Me/zwave-smarthome/issues/56