### PR TITLE
Fix closed window icon

### DIFF
--- a/app/icons.js
+++ b/app/icons.js
@@ -23,7 +23,9 @@ var icon_data = {
                         half: 'window-half.png',
                         up: 'window-up.png',
                         open: 'window-open.png',
-                        closed: 'window-open.png'
+                        closed: 'window-closed.png',
+                        on: 'window-open.png',
+                        off: 'window-closed.png'
                     }
                 },
                 switch : {


### PR DESCRIPTION
I'm using icon type 'window' for binary sensors that monitor windows. Since these sensors report 'on' or 'off' I added both states to the icon definition. Furthermore 'closed' was wrongly mapped against 'window-open.png'
