### PR TITLE
Add CO/CO2 alarms to Hazard Automation

### DIFF
--- a/app/controllers/automation-hazard.js
+++ b/app/controllers/automation-hazard.js
@@ -128,7 +128,25 @@ myAppController.controller('HazardNotificationIdController', function($scope, $r
 		},
 		tab: 'fire',
 		hazardsTypes: ['fire', 'leakage'],
-		sensors: ['smoke', 'alarm_smoke', 'alarmSensor_smoke', 'flood', 'alarm_flood', 'alarmSensor_flood', 'general_purpose'],
+		sensors: [
+			// smoke alarm
+			'smoke',
+			'alarm_smoke',
+			'alarmSensor_smoke',
+			// CO alarm
+			'co',
+			'alarm_co',
+			'alarmSensor_co',
+			// CO2 alarm
+			'coo',
+			'alarm_coo',
+			'alarmSensor_coo',
+			// flood
+			'flood',
+			'alarm_flood',
+			'alarmSensor_flood',
+			'general_purpose'
+		],
 		devices: ['switchBinary', 'switchMultilevel', 'switchRGBW', 'toggleButton'],
 		interval: [60, 120, 300, 600, 900, 1800, 3600],
 		firedOn: ['on', 'off', 'alarm', 'revert'],
@@ -136,7 +154,6 @@ myAppController.controller('HazardNotificationIdController', function($scope, $r
 		availableSensors: {},
 		availableDevices: {},
 		availableNotifiers: {},
-		devicesInRoom: [],
 		devicesInRoom: [],
 		rooms: [],
 		cfg: {


### PR DESCRIPTION
As a user I can add only smoke detectors, but I should be able to add other supported devices.